### PR TITLE
Feature/macos arm

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,10 +65,26 @@ jobs:
             UDA_REF: "2.9.3"
             FMT_REF: "11.1.4"
 
-          # # - os: macos-13
-          # #   python: 311
-          # #   platform_id: macosx_x86_64
+          - os: macos-13
+            triplet: x64-osx
+            python: 311
+            platform_id: macosx_x86_64
+            cibw_platform: macos
+            cibw_archs: x86_64
+            AL_BACKEND_HDF5: AL_BACKEND_HDF5=ON
+            AL_BACKEND_MDSPLUS: AL_BACKEND_MDSPLUS=OFF
+            AL_BACKEND_UDA: AL_BACKEND_UDA=OFF
 
+          - os: macos-14
+            triplet: arm64-osx
+            python: 311
+            platform_id: macosx_arm64
+            cibw_platform: macos
+            cibw_archs: arm64
+            AL_BACKEND_HDF5: AL_BACKEND_HDF5=ON
+            AL_BACKEND_MDSPLUS: AL_BACKEND_MDSPLUS=OFF
+            AL_BACKEND_UDA: AL_BACKEND_UDA=OFF
+    
           - os: windows-2022
             triplet: x64-windows
             python: 310
@@ -249,6 +265,28 @@ jobs:
             cmake.define.${{ matrix.AL_BACKEND_HDF5 }}
             cmake.define.${{ matrix.AL_BACKEND_MDSPLUS }}
             cmake.define.${{ matrix.AL_BACKEND_UDA }}
+
+        with:
+          package-dir: .
+          output-dir: wheelhouse
+          config-file: "{package}/pyproject.toml"
+
+      - uses: pypa/cibuildwheel@v3.0.0
+        if: startsWith(matrix.os, 'macos-')
+        env:
+          CIBW_BUILD: cp${{ matrix.python }}-${{ matrix.platform_id }}
+          CIBW_PLATFORM: macos
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+
+          CIBW_CONFIG_SETTINGS: >
+            cmake.define.${{ matrix.AL_BACKEND_HDF5 }}
+            cmake.define.${{ matrix.AL_BACKEND_MDSPLUS }}
+            cmake.define.${{ matrix.AL_BACKEND_UDA }}
+
+          # Dependency installation
+          CIBW_BEFORE_ALL_MACOS: >
+            brew update;
+            brew install cmake pkg-config boost hdf5 libomp;
 
         with:
           package-dir: .

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -65,16 +65,6 @@ jobs:
             UDA_REF: "2.9.3"
             FMT_REF: "11.1.4"
 
-          - os: macos-13
-            triplet: x64-osx
-            python: 311
-            platform_id: macosx_x86_64
-            cibw_platform: macos
-            cibw_archs: x86_64
-            AL_BACKEND_HDF5: AL_BACKEND_HDF5=ON
-            AL_BACKEND_MDSPLUS: AL_BACKEND_MDSPLUS=OFF
-            AL_BACKEND_UDA: AL_BACKEND_UDA=OFF
-
           - os: macos-14
             triplet: arm64-osx
             python: 311

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,16 +69,11 @@ if(NOT PROJECT_VERSION_TWEAK EQUAL 0)
   message("Building a development version of the Access Layer core")
 endif()
 
-# macOS RPATH handling
-# ##############################################################################
-
 if(APPLE)
-  set(CMAKE_MACOSX_RPATH ON)
-  set(CMAKE_INSTALL_RPATH "@loader_path/../imas_core.libs")
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
-  # force UDA off for now:
-  message(STATUS "Disabling UDA backend on macOS")
+  # Disable extra backends for now:
+  message(STATUS "Disabling UDA and MDSPlus backends on macOS")
   set(AL_BACKEND_UDA OFF CACHE BOOL "UDA backend" FORCE)    
+  set(AL_BACKEND_MDSPLUS OFF CACHE BOOL "MDSPlus backend" FORCE)    
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,15 @@ if(NOT PROJECT_VERSION_TWEAK EQUAL 0)
   message("Building a development version of the Access Layer core")
 endif()
 
+# macOS RPATH handling
+# ##############################################################################
+
+if(APPLE)
+  set(CMAKE_MACOSX_RPATH ON)
+  set(CMAKE_INSTALL_RPATH "@loader_path")
+  set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+endif()
+
 
 # Dependencies
 # ##############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,11 @@ endif()
 
 if(APPLE)
   set(CMAKE_MACOSX_RPATH ON)
-  set(CMAKE_INSTALL_RPATH "@loader_path")
+  set(CMAKE_INSTALL_RPATH "@loader_path/../imas_core.libs")
   set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
+  # force UDA off for now:
+  message(STATUS "Disabling UDA backend on macOS")
+  set(AL_BACKEND_UDA OFF CACHE BOOL "UDA backend" FORCE)    
 endif()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,14 @@ VCPKG_KEEP_ENV_VARS = "VCPKG_ROOT;CMAKE_PREFIX_PATH;CMAKE_TOOLCHAIN_FILE;CMAKE_P
 before-build = "bash ./ci/wheels/cibw_before_build_win.sh"
 repair-wheel-command = "bash ./ci/wheels/repair_windows.sh {wheel} {dest_dir}"
 
+[tool.cibuildwheel.macos.environment]
+CMAKE_PREFIX_PATH = "/opt/homebrew;/usr/local"
+PKG_CONFIG_PATH = "/opt/homebrew/lib/pkgconfig:/usr/local/lib/pkgconfig"
+MACOSX_DEPLOYMENT_TARGET = "11.0"
+
+[tool.cibuildwheel.macos]
+repair-wheel-command = "delocate-wheel -w {dest_dir} {wheel}"
+   
 [tool.scikit-build.cmake.define]
 BUILD_SHARED_LIBS = "ON"
 DOCS_ONLY = { env = "DOCS_ONLY", default = "OFF" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ PKG_CONFIG_PATH = "/opt/homebrew/lib/pkgconfig:/usr/local/lib/pkgconfig"
 MACOSX_DEPLOYMENT_TARGET = "11.0"
 
 [tool.cibuildwheel.macos]
+archs = ["arm64"]
 repair-wheel-command = "delocate-wheel -w {dest_dir} {wheel}"
    
 [tool.scikit-build.cmake.define]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ repair-wheel-command = "bash ./ci/wheels/repair_windows.sh {wheel} {dest_dir}"
 [tool.cibuildwheel.macos.environment]
 CMAKE_PREFIX_PATH = "/opt/homebrew;/usr/local"
 PKG_CONFIG_PATH = "/opt/homebrew/lib/pkgconfig:/usr/local/lib/pkgconfig"
-MACOSX_DEPLOYMENT_TARGET = "11.0"
+MACOSX_DEPLOYMENT_TARGET = "14.0"
 
 [tool.cibuildwheel.macos]
 archs = ["arm64"]

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -7,8 +7,32 @@ python_add_library(_al_lowlevel MODULE ${_al_lowlevel_source} WITH_SOABI)
 python_add_library(al_defs MODULE ${al_defs_source} WITH_SOABI)
 target_link_libraries(_al_lowlevel PRIVATE Python::NumPy al)
 target_link_libraries(al_defs PRIVATE Python::NumPy al)
-set_target_properties(al PROPERTIES INSTALL_RPATH $ORIGIN)
-set_target_properties(_al_lowlevel al_defs PROPERTIES INSTALL_RPATH $ORIGIN/../imas_core.libs)
+
+# Handling RPATH in Linux and macOS:
+if(APPLE)
+  set(_IMAS_RPATH_SELF "@loader_path")
+  set(_IMAS_RPATH_LIBS "@loader_path/../imas_core.libs")
+elseif(UNIX)
+  set(_IMAS_RPATH_SELF "$ORIGIN")
+  set(_IMAS_RPATH_LIBS "$ORIGIN/../imas_core.libs")
+else()
+  # Windows: no RPATH
+  set(_IMAS_RPATH_SELF "")
+  set(_IMAS_RPATH_LIBS "")
+endif()
+
+if(_IMAS_RPATH_SELF)
+  set_target_properties(al PROPERTIES
+    INSTALL_RPATH "${_IMAS_RPATH_SELF}"
+  )
+endif()
+
+if(_IMAS_RPATH_LIBS)
+  set_target_properties(_al_lowlevel al_defs PROPERTIES
+    INSTALL_RPATH "${_IMAS_RPATH_LIBS}"
+  )
+endif()
+    
 install(FILES $<TARGET_RUNTIME_DLLS:al> DESTINATION imas_core.libs)
 install(FILES $<TARGET_RUNTIME_DLLS:_al_lowlevel> DESTINATION imas_core.libs)
 install(FILES $<TARGET_RUNTIME_DLLS:al_defs> DESTINATION imas_core.libs)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,31 +8,15 @@ python_add_library(al_defs MODULE ${al_defs_source} WITH_SOABI)
 target_link_libraries(_al_lowlevel PRIVATE Python::NumPy al)
 target_link_libraries(al_defs PRIVATE Python::NumPy al)
 
-# Handling RPATH in Linux and macOS:
+# Handling RPATH in macOS:
 if(APPLE)
-  set(_IMAS_RPATH_SELF "@loader_path")
-  set(_IMAS_RPATH_LIBS "@loader_path/../imas_core.libs")
-elseif(UNIX)
-  set(_IMAS_RPATH_SELF "$ORIGIN")
-  set(_IMAS_RPATH_LIBS "$ORIGIN/../imas_core.libs")
+  set_target_properties(al PROPERTIES INSTALL_RPATH "@loader_path")
+  set_target_properties(_al_lowlevel al_defs PROPERTIES INSTALL_RPATH "@loader_path/../imas_core.libs")
 else()
-  # Windows: no RPATH
-  set(_IMAS_RPATH_SELF "")
-  set(_IMAS_RPATH_LIBS "")
+  set_target_properties(al PROPERTIES INSTALL_RPATH $ORIGIN)
+  set_target_properties(_al_lowlevel al_defs PROPERTIES INSTALL_RPATH $ORIGIN/../imas_core.libs)
 endif()
-
-if(_IMAS_RPATH_SELF)
-  set_target_properties(al PROPERTIES
-    INSTALL_RPATH "${_IMAS_RPATH_SELF}"
-  )
-endif()
-
-if(_IMAS_RPATH_LIBS)
-  set_target_properties(_al_lowlevel al_defs PROPERTIES
-    INSTALL_RPATH "${_IMAS_RPATH_LIBS}"
-  )
-endif()
-    
+            
 install(FILES $<TARGET_RUNTIME_DLLS:al> DESTINATION imas_core.libs)
 install(FILES $<TARGET_RUNTIME_DLLS:_al_lowlevel> DESTINATION imas_core.libs)
 install(FILES $<TARGET_RUNTIME_DLLS:al_defs> DESTINATION imas_core.libs)

--- a/src/no_backend.h
+++ b/src/no_backend.h
@@ -29,14 +29,14 @@ public:
   ~NoBackend() {};
 
   void openPulse(DataEntryContext *ctx,
-		 int mode);
+		 int mode) override;
 
   void closePulse(DataEntryContext *ctx,
-		  int mode);
+		  int mode) override;
 
-  void beginAction(OperationContext *ctx);
+  void beginAction(OperationContext *ctx) override;
 
-  void endAction(Context *ctx);
+  void endAction(Context *ctx) override;
 
   void writeData(Context *ctx,
 		 std::string fieldname,
@@ -44,7 +44,7 @@ public:
 		 void* data,
 		 int datatype,
 		 int dim,
-		 int* size);
+		 int* size) override;
 
   int readData(Context *ctx,
 	       std::string fieldname,
@@ -52,26 +52,26 @@ public:
 	       void** data,
 	       int* datatype,
 	       int* dim,
-	       int* size);
+	       int* size) override;
 
   void deleteData(OperationContext *ctx,
-		  std::string path);
+		  std::string path) override;
 
   void beginArraystructAction(ArraystructContext *ctx,
-			      int *size);
+			      int *size) override;
 
-  std::pair<int,int> getVersion(DataEntryContext *ctx);
+  std::pair<int,int> getVersion(DataEntryContext *ctx) override;
 
   void get_occurrences(Context* ctx, const  char* ids_name, int** occurrences_list, int* size) override;
 
-  bool supportsTimeDataInterpolation() {
+  bool supportsTimeDataInterpolation() override {
       return false;
     }
 
-  void initDataInterpolationComponent() {
+  void initDataInterpolationComponent() override {
   }
 
-  bool supportsTimeRangeOperation() {
+  bool supportsTimeRangeOperation() override {
 	  return false;
 	}
 


### PR DESCRIPTION
This PR adds native Apple Silicon (arm64) macOS wheels for IMAS-Core.

Partially fixes #18 , since :

- Universal2 (Intel + arm64) support was intentionally deferred until explicitly requested.
- Only hdf5 backend for now, UDA and MDSPlus not included yet.