### PR TITLE
Add `--no-index` to installation command for imas_core

### DIFF
--- a/skbuild.cmake
+++ b/skbuild.cmake
@@ -51,6 +51,7 @@ set_target_properties(
   al-python-bindings PROPERTIES DIST_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/dist/)
 install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} 
 -m pip install imas_core
+--no-index
 --prefix=${CMAKE_INSTALL_PREFIX}
 --find-links ${CMAKE_CURRENT_BINARY_DIR}/dist/
 )"


### PR DESCRIPTION
Ensure that pip installs the just-built version of imas_core instead of downloading it from PyPI.

As found out in discussions with Bartek Palak this afternoon.