### PR TITLE
Create test for loading two IDS files in sequence.

### DIFF
--- a/python/tests/test_backend.py
+++ b/python/tests/test_backend.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+
+import imas_core
+
+lowlevel = imas_core._al_lowlevel
+imasdef = imas_core.imasdef
+
+
+def create_temp_ids_file(content: str, suffix: str = "") -> str:
+  tmpdir = os.environ.get("TEST_TMPDIR", ".")
+  filename = os.path.join(tmpdir, f"test_temp{suffix}.ids")
+  with open(filename, "w") as f:
+    f.write(content)
+  return filename
+
+
+class TestAsciiBackendStatePersistence:
+  """Test that reading two IDS files in sequence correctly clears state.
+
+  This is a Python version of the C++ backend_regression_test.cpp that verifies
+  the AsciiBackend properly clears its internal stringstream state between
+  reads.
+  """
+
+  def test_state_persistence(self):
+    content1 = "test_temp_state1/data1\n\ttype: 51 (integer)\n\tdim: 0\n123\n"
+    create_temp_ids_file(content1, "_state1")
+
+    content2 = "test_temp_state2/data2\n\ttype: 51 (integer)\n\tdim: 0\n456\n"
+    create_temp_ids_file(content2, "_state2")
+
+    tmpdir = os.environ.get("TEST_TMPDIR", ".")
+    uri = f"imas:ascii?path={tmpdir}"
+
+    status, de_ctx = lowlevel.al_begin_dataentry_action(uri, imasdef.OPEN_PULSE)
+    assert status >= 0, f"Failed to open pulse: status={status}"
+
+    status, op_ctx1 = lowlevel.al_begin_global_action(
+        de_ctx, "test_temp_state1", imasdef.READ_OP
+    )
+    assert status >= 0, f"Failed to begin first action: status={status}"
+
+    status, data1 = lowlevel.al_read_data(
+        op_ctx1, "data1", "", imasdef.INTEGER_DATA, 0
+    )
+    assert status >= 0, f"Failed to read first data: status={status}"
+    assert data1 == 123, f"Expected 123, got {data1}"
+
+    lowlevel.al_end_action(op_ctx1)
+
+    status, op_ctx2 = lowlevel.al_begin_global_action(
+        de_ctx, "test_temp_state2", imasdef.READ_OP
+    )
+    assert status >= 0, f"Failed to begin second action: status={status}"
+
+    status, data2 = lowlevel.al_read_data(
+        op_ctx2, "data2", "", imasdef.INTEGER_DATA, 0
+    )
+    assert status >= 0, f"Failed to read second data: status={status}"
+    assert data2 == 456, f"Expected 456, got {data2}"
+
+    lowlevel.al_end_action(op_ctx2)
+
+    lowlevel.al_close_pulse(de_ctx, imasdef.CLOSE_PULSE)
+
+
+if __name__ == "__main__":
+  pytest.main([__file__])
+

--- a/python/tests/test_backend.py
+++ b/python/tests/test_backend.py
@@ -1,71 +1,59 @@
 import os
+import pathlib
 
 import pytest
 
 import imas_core
 
-lowlevel = imas_core._al_lowlevel
-imasdef = imas_core.imasdef
 
-
-def create_temp_ids_file(content: str, suffix: str = "") -> str:
-  tmpdir = os.environ.get("TEST_TMPDIR", ".")
-  filename = os.path.join(tmpdir, f"test_temp{suffix}.ids")
+def _create_temp_ids_file(
+    content: str, suffix: str, tmp_path: pathlib.Path
+) -> str:
+  filename = os.path.join(tmp_path, f"test_temp{suffix}.ids")
   with open(filename, "w") as f:
     f.write(content)
   return filename
 
 
-class TestAsciiBackendStatePersistence:
-  """Test that reading two IDS files in sequence correctly clears state.
+def test_state_persistence(tmp_path: pathlib.Path):
+  """Test that reading two IDS files in sequence correctly clears state."""
 
-  This is a Python version of the C++ backend_regression_test.cpp that verifies
-  the AsciiBackend properly clears its internal stringstream state between
-  reads.
-  """
+  content1 = "test_temp_state1/data1\n\ttype: 51 (integer)\n\tdim: 0\n123\n"
+  _create_temp_ids_file(content1, "_state1", tmp_path)
 
-  def test_state_persistence(self):
-    content1 = "test_temp_state1/data1\n\ttype: 51 (integer)\n\tdim: 0\n123\n"
-    create_temp_ids_file(content1, "_state1")
+  content2 = "test_temp_state2/data2\n\ttype: 51 (integer)\n\tdim: 0\n456\n"
+  _create_temp_ids_file(content2, "_state2", tmp_path)
 
-    content2 = "test_temp_state2/data2\n\ttype: 51 (integer)\n\tdim: 0\n456\n"
-    create_temp_ids_file(content2, "_state2")
+  uri = f"imas:ascii?path={tmp_path}"
 
-    tmpdir = os.environ.get("TEST_TMPDIR", ".")
-    uri = f"imas:ascii?path={tmpdir}"
+  _, de_ctx = imas_core.lowlevel.al_begin_dataentry_action(
+      uri, imas_core.imasdef.OPEN_PULSE
+  )
 
-    status, de_ctx = lowlevel.al_begin_dataentry_action(uri, imasdef.OPEN_PULSE)
-    assert status >= 0, f"Failed to open pulse: status={status}"
+  _, op_ctx1 = imas_core.lowlevel.al_begin_global_action(
+      de_ctx, "test_temp_state1", imas_core.imasdef.READ_OP
+  )
 
-    status, op_ctx1 = lowlevel.al_begin_global_action(
-        de_ctx, "test_temp_state1", imasdef.READ_OP
-    )
-    assert status >= 0, f"Failed to begin first action: status={status}"
+  _, data1 = imas_core.lowlevel.al_read_data(
+      op_ctx1, "data1", "", imas_core.imasdef.INTEGER_DATA, 0
+  )
+  assert data1 == 123, f"Expected 123, got {data1}"
 
-    status, data1 = lowlevel.al_read_data(
-        op_ctx1, "data1", "", imasdef.INTEGER_DATA, 0
-    )
-    assert status >= 0, f"Failed to read first data: status={status}"
-    assert data1 == 123, f"Expected 123, got {data1}"
+  imas_core.lowlevel.al_end_action(op_ctx1)
 
-    lowlevel.al_end_action(op_ctx1)
+  _, op_ctx2 = imas_core.lowlevel.al_begin_global_action(
+      de_ctx, "test_temp_state2", imas_core.imasdef.READ_OP
+  )
 
-    status, op_ctx2 = lowlevel.al_begin_global_action(
-        de_ctx, "test_temp_state2", imasdef.READ_OP
-    )
-    assert status >= 0, f"Failed to begin second action: status={status}"
+  _, data2 = imas_core.lowlevel.al_read_data(
+      op_ctx2, "data2", "", imas_core.imasdef.INTEGER_DATA, 0
+  )
+  assert data2 == 456, f"Expected 456, got {data2}"
 
-    status, data2 = lowlevel.al_read_data(
-        op_ctx2, "data2", "", imasdef.INTEGER_DATA, 0
-    )
-    assert status >= 0, f"Failed to read second data: status={status}"
-    assert data2 == 456, f"Expected 456, got {data2}"
+  imas_core.lowlevel.al_end_action(op_ctx2)
 
-    lowlevel.al_end_action(op_ctx2)
-
-    lowlevel.al_close_pulse(de_ctx, imasdef.CLOSE_PULSE)
+  imas_core.lowlevel.al_close_pulse(de_ctx, imas_core.imasdef.CLOSE_PULSE)
 
 
 if __name__ == "__main__":
   pytest.main([__file__])
-


### PR DESCRIPTION
Add test that should fail when two IDS files are loaded in sequence.

This test fails when building imas_core on our build system. I have some proposed fixes for this test but would like to see if the failure is reproducible on your build system too.