### PR TITLE
Proposed fix for IMAS-5428: Issue with imas.create() for HDF5 files when badly closed

### DIFF
--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -293,7 +293,8 @@ void HDF5Utils::openMasterFile(hid_t *file_id, const std::string &filePath, bool
         if (*file_id < 0) {
             if (for_deletion) {
                 remove(filePath.c_str());
-                //printf("WARNING: The HDF5 master file '%s' was probably corrupted. It has been deleted and the linked IDS files could not be deleted automatically.\n", filePath.c_str());
+                printf("WARNING: The HDF5 master file '%s' was corrupted and re-created, but linked \
+                IDS h5 files may remain and would need to be removed manually unless replaced by subsequent write operations.\n", filePath.c_str());
                 *file_id = -1;
                 return;
             } else {
@@ -302,9 +303,6 @@ void HDF5Utils::openMasterFile(hid_t *file_id, const std::string &filePath, bool
                 throw ALBackendException(message, LOG);
             }
         }
-		else {
-			//printf("master file read successfully with file_id=%d\n", *file_id);
-		}
     }
     
 }

--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -270,14 +270,6 @@ void HDF5Utils::openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, h
 
                 createIDSFile(ctx, IDSpulseFile, backend_version, IDS_file_id);
 
-                //*IDS_file_id = H5Fopen(IDSpulseFile.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-
-                /*if (*IDS_file_id < 0) { 
-                    char error_message[200];
-                    sprintf(error_message, "Unable to open external file in Read-Write mode for IDS: %s. Unknow reason.\n", ctx->getDataobjectName().c_str());
-                    throw ALBackendException(error_message, LOG);
-                }*/
-
             }
             
 	        
@@ -405,11 +397,6 @@ herr_t file_info(hid_t loc_id, const char *IDS_link_name, const H5L_info_t * lin
     std::string IDSpulseFile = hdf5_utils.getIDSPulseFilePath(od->files_directory, od->relative_file_path, std::string(IDS_link_name));
     if (exists(IDSpulseFile.c_str())) {
         hid_t IDS_file_id = H5Fopen(IDSpulseFile.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-        /*if (IDS_file_id < 0) {
-            std::string message("Unable to open external file: ");
-            message += IDSpulseFile;
-            throw ALBackendException(message, LOG);
-        }*/
         if (IDS_file_id >= 0)
             hdf5_utils.closeIDSFile(IDS_file_id, IDS_link_name); //closing the IDS file
     }

--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <iostream>
 #include <fstream>
+#include <errno.h>
 #include <boost/filesystem.hpp>
 
 using namespace boost::filesystem;
@@ -178,7 +179,10 @@ void HDF5Utils::deleteIDSFile(const std::string &filePath) {
 void HDF5Utils::deleteMasterFile(const std::string &filePath, hid_t *file_id, std::unordered_map < std::string, hid_t > &opened_IDS_files, std::string &files_directory, std::string &relative_file_path) {
 
     if (exists(filePath.c_str())) {
-        openMasterFile(file_id, filePath);
+        openMasterFile(file_id, filePath, true);
+        if (*file_id == -1) {
+            return;
+        }
         initExternalLinks(file_id, opened_IDS_files, files_directory, relative_file_path);
         deleteIDSFiles(opened_IDS_files, files_directory, relative_file_path);
         closeMasterFile(file_id);
@@ -237,7 +241,7 @@ void HDF5Utils::createIDSFile(OperationContext * ctx, std::string &IDSpulseFile,
 
 }
 
-void HDF5Utils::openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, hid_t *IDS_file_id, bool try_read_only) {
+void HDF5Utils::openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, hid_t *IDS_file_id, bool try_read_only, std::string backend_version) {
     if (!exists(IDSpulseFile.c_str()))
 	    return;
     *IDS_file_id = H5Fopen(IDSpulseFile.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
@@ -254,15 +258,34 @@ void HDF5Utils::openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, h
 			}
         }
         else {
-		    char error_message[200];
-		    sprintf(error_message, "Unable to open external file in Read-Write mode for IDS: %s. It might indicate that the file is being currently handled by a writing concurrent process.\n", ctx->getDataobjectName().c_str());
-		    throw ALBackendException(error_message, LOG);
+		    if (errno == EAGAIN || errno == EACCES || errno == EBUSY) {
+                char error_message[200];
+		        sprintf(error_message, "Unable to open external file in Read-Write mode for IDS: %s. It might indicate that the file is being currently handled by a writing concurrent process.\n", ctx->getDataobjectName().c_str());
+                throw ALBackendException(error_message, LOG);
+            }
+            else {
+                //H5Eprint(H5E_DEFAULT, stderr);
+                remove(IDSpulseFile.c_str());
+                *IDS_file_id = -2;
+
+                createIDSFile(ctx, IDSpulseFile, backend_version, IDS_file_id);
+
+                //*IDS_file_id = H5Fopen(IDSpulseFile.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+
+                /*if (*IDS_file_id < 0) { 
+                    char error_message[200];
+                    sprintf(error_message, "Unable to open external file in Read-Write mode for IDS: %s. Unknow reason.\n", ctx->getDataobjectName().c_str());
+                    throw ALBackendException(error_message, LOG);
+                }*/
+
+            }
+            
 	        
         }
     }
 }
 
-void HDF5Utils::openMasterFile(hid_t *file_id, const std::string &filePath) { //open master file
+void HDF5Utils::openMasterFile(hid_t *file_id, const std::string &filePath, bool for_deletion) { //open master file
     if (*file_id != -1)
       return;
     if (!exists(filePath)) {
@@ -276,9 +299,16 @@ void HDF5Utils::openMasterFile(hid_t *file_id, const std::string &filePath) { //
     if (*file_id < 0) { //have a try now in read only access
         *file_id = H5Fopen(filePath.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
         if (*file_id < 0) {
-            std::string message("Unable to open HDF5 master file: ");
-            message += filePath;
-            throw ALBackendException(message, LOG);
+            if (for_deletion) {
+                remove(filePath.c_str());
+                //printf("WARNING: The HDF5 master file '%s' was probably corrupted. It has been deleted and the linked IDS files could not be deleted automatically.\n", filePath.c_str());
+                *file_id = -1;
+                return;
+            } else {
+                std::string message("Unable to open HDF5 master file: ");
+                message += filePath;
+                throw ALBackendException(message, LOG);
+            }
         }
 		else {
 			//printf("master file read successfully with file_id=%d\n", *file_id);
@@ -375,17 +405,13 @@ herr_t file_info(hid_t loc_id, const char *IDS_link_name, const H5L_info_t * lin
     std::string IDSpulseFile = hdf5_utils.getIDSPulseFilePath(od->files_directory, od->relative_file_path, std::string(IDS_link_name));
     if (exists(IDSpulseFile.c_str())) {
         hid_t IDS_file_id = H5Fopen(IDSpulseFile.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
-        if (IDS_file_id < 0) {
+        /*if (IDS_file_id < 0) {
             std::string message("Unable to open external file: ");
             message += IDSpulseFile;
             throw ALBackendException(message, LOG);
-       
-            /*if (!od->mode) {
-                if (H5Lexists(IDS_file_id, IDS_link_name, H5P_DEFAULT) > 0)
-                    H5Ldelete(IDS_file_id, IDS_link_name, H5P_DEFAULT);
-            }*/
-        }
-        hdf5_utils.closeIDSFile(IDS_file_id, IDS_link_name); //closing the IDS file
+        }*/
+        if (IDS_file_id >= 0)
+            hdf5_utils.closeIDSFile(IDS_file_id, IDS_link_name); //closing the IDS file
     }
     od->link_names[od->count] = (char *) malloc(100);
     strcpy(od->link_names[od->count], IDS_link_name);
@@ -755,5 +781,3 @@ void HDF5Utils::readOptions(uri::Uri uri, bool *compression_enabled, bool *readB
       *write_cache = (size_t) (atof(value.c_str()) * 1024 * 1024);
     }
 }
-
-

--- a/src/hdf5/hdf5_utils.h
+++ b/src/hdf5/hdf5_utils.h
@@ -39,7 +39,7 @@ class HDF5Utils {
     std::string getPulseFilePath(DataEntryContext * ctx, int mode, int strategy, std::string & files_directory, std::string & relative_file_path);
     void deleteIDSFiles(std::unordered_map < std::string, hid_t > &opened_IDS_files, std::string & files_directory, std::string & relative_file_path);
     void createMasterFile(DataEntryContext * ctx, std::string &filePath, hid_t *file_id, std::string &backend_version);
-    void openMasterFile(hid_t *file_id, const std::string &filePath);
+    void openMasterFile(hid_t *file_id, const std::string &filePath, bool for_deletion = false);
     void initExternalLinks(hid_t *file_id, std::unordered_map < std::string, hid_t > &opened_IDS_files, std::string &files_directory, std::string &relative_file_path);
 
   public:
@@ -58,7 +58,7 @@ class HDF5Utils {
     bool pulseFileExists(const std::string &IDS_pulse_file);
     void closeMasterFile(hid_t *file_id);
     void removeLinkFromMasterPulseFile(hid_t &file_id, const std::string &link_name);
-    void openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, hid_t *IDS_file_id, bool try_read_only);
+    void openIDSFile(OperationContext * ctx, std::string &IDSpulseFile, hid_t *IDS_file_id, bool try_read_only, std::string backend_version = "");
     void closeIDSFile(hid_t pulse_file_id, const std::string &external_link_name) ;
     void createIDSFile(OperationContext * ctx, std::string &IDSpulseFile, std::string &backend_version, hid_t *IDS_file_id);
     void removeLinkFromIDSPulseFile(hid_t &IDS_file_id, const std::string &IDS_link_name);

--- a/src/hdf5/hdf5_writer.cpp
+++ b/src/hdf5/hdf5_writer.cpp
@@ -138,7 +138,7 @@ void HDF5Writer::create_IDS_group(OperationContext * ctx, hid_t file_id, std::un
                 hdf5_utils.createIDSFile(ctx, IDSpulseFile, backend_version, &IDS_file_id);
             }
             else {
-                hdf5_utils.openIDSFile(ctx, IDSpulseFile, &IDS_file_id, false);
+                hdf5_utils.openIDSFile(ctx, IDSpulseFile, &IDS_file_id, false, backend_version);
             }
         
         opened_IDS_files[IDS_link_name] = IDS_file_id;
@@ -150,7 +150,7 @@ void HDF5Writer::create_IDS_group(OperationContext * ctx, hid_t file_id, std::un
                 hdf5_utils.createIDSFile(ctx, IDSpulseFile, backend_version, &IDS_file_id);
             }
             else {
-                hdf5_utils.openIDSFile(ctx, IDSpulseFile, &IDS_file_id, false);
+                hdf5_utils.openIDSFile(ctx, IDSpulseFile, &IDS_file_id, false, backend_version);
             }
             
             opened_IDS_files[IDS_link_name] = IDS_file_id;


### PR DESCRIPTION
This patch is a solution for the request/issue reported on IITER JIRA (ticket **IMAS-5428**):

**Description of the issue:**
If I cancel a job writing an IMAS output datafile in the HDF5 format, and I launch the job again, I recreates the datafile, but it crashes on the put() command, likely because the file is corrupted and imas.create() does not properly remove/replace the master.h5 file.

This problem occurs on Centos both with IMAS/3.41.0-4.11.10-2020b and IMAS/3.41.0-2024.07-intel-2023b. It occurs also on RedHat with IMAS/3.42.0-2024.08-intel-2023b.

The corrupted file is here: /home/ITER/schneim/public/imasdb/DEBUG/3/100020/123/master.h5

Here is a script to reproduce the issue:

```
import imas, os
output = imas.DBEntry(imas.imasdef.HDF5_BACKEND,'DEBUG',100020,123,os.getenv('USER'))
output.create()
core_profiles = imas.core_profiles()
core_profiles.ids_properties.homogeneous_time = 1
core_profiles.time.resize(1)
output.put(core_profiles)
output.close() 
```
The error message is the following:

> ERROR:root:b'al_begin_dataentry_action: [ALBackendException = Unable to open HDF5 master file: /home/ITER/schneim/public/imasdb/DEBUG/3/100020/123/master.h5]'
> ERROR:root:b'al_plugin_begin_global_action: [ALBackendException = Unable to open HDF5 master file: /home/ITER/schneim/public/imasdb/DEBUG/3/100020/123/master.h5]'
> ERROR:root:b'al_plugin_begin_global_action: [ALBackendException = Unable to open HDF5 master file: /home/ITER/schneim/public/imasdb/DEBUG/3/100020/123/master.h5]'
> Traceback (most recent call last):
>   File "/home/ITER/schneim/public/git/torbeam/tests/test_imas/hdtest.py", line 10, in <module>
>     output.put(core_profiles)
>   File "/work/imas/opt/EasyBuild/software/IMAS-AL-Python/5.2.2-intel-2023b-DD-3.42.0/lib/python3.11/site-packages/imas/db_entry.py", line 501, in put
>     ids.put(occurrence, self)
>   File "/work/imas/opt/EasyBuild/software/IMAS-AL-Python/5.2.2-intel-2023b-DD-3.42.0/lib/python3.11/site-packages/imas/core_profiles.py", line 1676, in put
>     raise ALException('Error calling al_begin_global_action() for core_profiles', status)
> imas_core.exception.ALException: Error calling al_begin_global_action() for core_profiles
> Error status=-3

If I change the run number to a brand new one, then it works. So it is about master.h5 which is not properly ignored and overwritten by the imas.create() command.

**Description of the patch:**
When creating a new DataEntry at the same URI with this patch, the hdf5 backend tries currentky to read the master.h5 file in order to remove the IDSs files referenced by the master file. If this one is corrupted, it is removed from the disk and the IDSs files are let on the disk (a warning could be printed in this case; this warning is currently commented at line 296 of hdf5_utils.cpp). In this case, the IDSs files that could not be removed automatically will be overwritten by the new DataEntry creation procedure. 

Please let me know if you prefer:
- that the IDSs files be removed automatically (in this case all .h5 files will be removed from the URI folder, even .h5 not belonging to the DataEntry (to be removed) since the backend can not distinguish the .h5 files belonging to this DataEntry, this information is unfortunately in the master file which is corrruped)
- that we keep the current behavior but enabling the warning that the IDSs files deletion could no be automatically performed.   
