### PR TITLE
Update MDSplus backend configuration configuration

### DIFF
--- a/common/al_env.sh.in
+++ b/common/al_env.sh.in
@@ -13,7 +13,7 @@ if [ -d "${CMAKE_INSTALL_PREFIX}/lib/python${PYVER}/site-packages" ]; then
     export PYTHONPATH="${CMAKE_INSTALL_PREFIX}/lib/python${PYVER}/site-packages:$PYTHONPATH"
 fi
 if [ -d "${CMAKE_INSTALL_PREFIX}/models/mdsplus" ]; then
-    export ids_path="${CMAKE_INSTALL_PREFIX}/models/mdsplus"
+    export MDSPLUS_MODELS_PATH="${CMAKE_INSTALL_PREFIX}/models/mdsplus"
 fi
 if [ -f "${CMAKE_INSTALL_PREFIX}/include/IDSDef.xml" ]; then
     export IDSDEF_PATH="${CMAKE_INSTALL_PREFIX}/include/IDSDef.xml"

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -102,6 +102,10 @@ Backend specific environment variables
     Specify the path to storing temporary data. If it is not set, the default
     location `/dev/shm/` or the current working directory will be chosen.
 
+``MDSPLUS_MODELS_PATH``
+    Specify the path where the MDSplus models files are stored for a given
+    version of the Data Dictionary (previously set by the `ids_path`, which
+    is now internally handled by the backend).
 
 
 UDA client configuration to reach the server at ITER

--- a/src/mdsplus/mdsplus_backend.cpp
+++ b/src/mdsplus/mdsplus_backend.cpp
@@ -1428,7 +1428,7 @@ static char *getPathInfo(MDSplus::Data *data, MDSplus::TreeNode *refNode)
 		std::string translatedBaseStr(translatedBase);
 		if(originalIdsPath == "")
 		{
-		    char *origPath = getenv(szPath);
+		    char *origPath = getenv("MDSPLUS_MODELS_PATH");
 		    if(origPath)
 		        originalIdsPath = origPath; 
 		}
@@ -1495,7 +1495,7 @@ void MDSplusBackend::resetIdsPath(std::string strTree) {
 	
 	if(originalIdsPath == "")  //Do it only once in case it is defined
 	{
-	    char *origPath = getenv(szPath);
+	    char *origPath = getenv("MDSPLUS_MODELS_PATH");
 	    if(origPath)
 	    	originalIdsPath = origPath; 
 	}


### PR DESCRIPTION
Note that this requires an associated PR in IMAS-Python, as this interface has the capability to update this configuration at runtime to change the targeted DD version.