### PR TITLE
Set default UDA local_cache path to /tmp/$USER

### DIFF
--- a/common/doc_common/imas_uri.rst
+++ b/common/doc_common/imas_uri.rst
@@ -248,6 +248,6 @@ The :ref:`UDA backend` also recognizes these backend-specific query keys.
     and downloading IDS files to the local ``local_cache`` directory.
 
 ``local_cache``
-    UDA ``local_cache`` is set to ``tmp/$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
+    UDA ``local_cache`` is set to ``tmp/uda-cache-of-$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
     Set ``local_cache=/path/to/local/cache/directory`` and the download directory will be ``local_cache/path_in_uri``.
     ``local_cache`` specifies the path to the local cache directory where IDSs will be downloaded.

--- a/common/doc_common/imas_uri.rst
+++ b/common/doc_common/imas_uri.rst
@@ -248,6 +248,6 @@ The :ref:`UDA backend` also recognizes these backend-specific query keys.
     and downloading IDS files to the local ``local_cache`` directory.
 
 ``local_cache``
-    UDA ``local_cache`` is set to ``tmp/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
+    UDA ``local_cache`` is set to ``tmp/$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
     Set ``local_cache=/path/to/local/cache/directory`` and the download directory will be ``local_cache/path_in_uri``.
     ``local_cache`` specifies the path to the local cache directory where IDSs will be downloaded.

--- a/docs/source/user_guide/backends_guide.rst
+++ b/docs/source/user_guide/backends_guide.rst
@@ -217,6 +217,6 @@ The :ref:`UDA backend` also recognizes these backend-specific query keys.
     and downloading IDS files to the local ``local_cache`` directory.
 
 ``local_cache``
-    UDA ``local_cache`` is set to ``tmp/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
+    UDA ``local_cache`` is set to ``tmp/$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
     Set ``local_cache=/path/to/local/cache/directory`` and the download directory will be ``local_cache/path_in_uri``.
     ``local_cache`` specifies the path to the local cache directory where IDSs will be downloaded.

--- a/docs/source/user_guide/backends_guide.rst
+++ b/docs/source/user_guide/backends_guide.rst
@@ -217,6 +217,6 @@ The :ref:`UDA backend` also recognizes these backend-specific query keys.
     and downloading IDS files to the local ``local_cache`` directory.
 
 ``local_cache``
-    UDA ``local_cache`` is set to ``tmp/$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
+    UDA ``local_cache`` is set to ``tmp/uda-cache-of-$USER/path_in_uri`` by default. This is used along with ``fetch=1`` in the query.
     Set ``local_cache=/path/to/local/cache/directory`` and the download directory will be ``local_cache/path_in_uri``.
     ``local_cache`` specifies the path to the local cache directory where IDSs will be downloaded.

--- a/src/uda/uda_backend.cpp
+++ b/src/uda/uda_backend.cpp
@@ -422,9 +422,9 @@ void UDABackend::fetch_files(const uri::Uri& uri)
 
     remote_path_ = std::filesystem::path{ maybe_path.value()};
     
-    // Determine cache path: explicit parameter, or default to /tmp/$USER/path_in_uri for isolation
+    // Determine cache path: explicit parameter, or default to /tmp/uda-cache-of-$USER/path_in_uri for isolation
     const char* user = std::getenv("USER");
-    auto cache_path = maybe_local_cache ? std::filesystem::path{maybe_local_cache.value()} : user ? std::filesystem::temp_directory_path() / user : std::filesystem::temp_directory_path();
+    auto cache_path = maybe_local_cache ? std::filesystem::path{maybe_local_cache.value()} : user ? std::filesystem::temp_directory_path() / ("uda-cache-of-" + std::string{user}) : std::filesystem::temp_directory_path() / "uda-cache";
     local_path_ = cache_path / remote_path_.relative_path();
     std::string backend = maybe_backend.value();
 

--- a/src/uda/uda_backend.cpp
+++ b/src/uda/uda_backend.cpp
@@ -421,7 +421,10 @@ void UDABackend::fetch_files(const uri::Uri& uri)
     }
 
     remote_path_ = std::filesystem::path{ maybe_path.value()};
-    auto cache_path = maybe_local_cache ? std::filesystem::path{maybe_local_cache.value()} : std::filesystem::temp_directory_path();
+    
+    // Determine cache path: explicit parameter, or default to /tmp/$USER/path_in_uri for isolation
+    const char* user = std::getenv("USER");
+    auto cache_path = maybe_local_cache ? std::filesystem::path{maybe_local_cache.value()} : user ? std::filesystem::temp_directory_path() / user : std::filesystem::temp_directory_path();
     local_path_ = cache_path / remote_path_.relative_path();
     std::string backend = maybe_backend.value();
 


### PR DESCRIPTION
- Modified default local_cache path to /tmp/$USER
- Updated documentation