### PR TITLE
fix(hdf5): read HDF5_BACKEND_VERSION using actual stored type(#42)

### DIFF
--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -101,6 +101,7 @@ int
             sprintf(error_message, "Unable to read attribute: %s\n", backend_version_attribute_name);
             throw ALBackendException(error_message, LOG);
         }
+        version[attr_size] = '\0';
         backend_version = version.c_str();
         H5Tclose(dtype_id);
         H5Aclose(att_id);

--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -92,7 +92,7 @@ int
         H5Tset_strpad(dtype_id, H5T_STR_NULLTERM);
         H5Tset_cset(dtype_id, attr_cset);
 
-        std::vector<char> version(attr_size + 1, '\0');
+        std::string version(attr_size + 1, '\0');
         herr_t status = H5Aread(att_id, dtype_id, version.data());
         if (status < 0) {
             H5Tclose(dtype_id);
@@ -101,7 +101,7 @@ int
             sprintf(error_message, "Unable to read attribute: %s\n", backend_version_attribute_name);
             throw ALBackendException(error_message, LOG);
         }
-        backend_version = std::string(version.data());
+        backend_version = version.c_str();
         H5Tclose(dtype_id);
         H5Aclose(att_id);
     } else {

--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -84,11 +84,13 @@ int
             throw ALBackendException(error_message, LOG);
         }
         size_t attr_size = H5Tget_size(attr_file_type);
+        H5T_cset_t attr_cset = H5Tget_cset(attr_file_type);
         H5Tclose(attr_file_type);
 
         hid_t dtype_id = H5Tcopy(H5T_C_S1);
         H5Tset_size(dtype_id, attr_size + 1);
         H5Tset_strpad(dtype_id, H5T_STR_NULLTERM);
+        H5Tset_cset(dtype_id, attr_cset);
 
         std::vector<char> version(attr_size + 1, '\0');
         herr_t status = H5Aread(att_id, dtype_id, version.data());

--- a/src/hdf5/hdf5_utils.cpp
+++ b/src/hdf5/hdf5_utils.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <fstream>
 #include <errno.h>
+#include <vector>
 #include <boost/filesystem.hpp>
 
 using namespace boost::filesystem;
@@ -75,24 +76,30 @@ int
             throw ALBackendException(error_message, LOG);
         }
 
-        hid_t dtype_id = H5Tcopy (H5T_C_S1);
-        H5Tset_size(dtype_id, strlen(backend_version_attribute_name));
-        
-        herr_t tset = H5Tset_cset(dtype_id, H5T_CSET_UTF8);
-        if (tset < 0) {
-            char error_message[100];
-            sprintf(error_message, "Unable to set characters to UTF8 for: %s\n", backend_version_attribute_name);
-            throw ALBackendException(error_message);
+        hid_t attr_file_type = H5Aget_type(att_id);
+        if (attr_file_type < 0) {
+            H5Aclose(att_id);
+            char error_message[200];
+            sprintf(error_message, "Unable to get type of attribute: %s\n", backend_version_attribute_name);
+            throw ALBackendException(error_message, LOG);
         }
+        size_t attr_size = H5Tget_size(attr_file_type);
+        H5Tclose(attr_file_type);
 
-        char version[10];
-        herr_t status = H5Aread(att_id, dtype_id, version);
+        hid_t dtype_id = H5Tcopy(H5T_C_S1);
+        H5Tset_size(dtype_id, attr_size + 1);
+        H5Tset_strpad(dtype_id, H5T_STR_NULLTERM);
+
+        std::vector<char> version(attr_size + 1, '\0');
+        herr_t status = H5Aread(att_id, dtype_id, version.data());
         if (status < 0) {
+            H5Tclose(dtype_id);
+            H5Aclose(att_id);
             char error_message[200];
             sprintf(error_message, "Unable to read attribute: %s\n", backend_version_attribute_name);
             throw ALBackendException(error_message, LOG);
         }
-        backend_version = std::string(version);
+        backend_version = std::string(version.data());
         H5Tclose(dtype_id);
         H5Aclose(att_id);
     } else {
@@ -344,8 +351,8 @@ void HDF5Utils::writeHeader(DataEntryContext * ctx, hid_t file_id, std::string &
 
     //write version to file
     hid_t dataspace_id = H5Screate(H5S_SCALAR);
-    hid_t dtype_id = H5Tcopy (H5T_C_S1);
-    H5Tset_size(dtype_id, strlen(backend_version_attribute_name));
+    hid_t dtype_id = H5Tcopy(H5T_C_S1);
+    H5Tset_size(dtype_id, backend_version.length() + 1);
     herr_t tset = H5Tset_cset(dtype_id, H5T_CSET_UTF8);
     if (tset < 0) {
         char error_message[200];


### PR DESCRIPTION
```
$ python
Python 3.11.5 (main, Jul 30 2025, 19:17:56) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import imas
>>> with imas.DBEntry("imas:hdf5?path=./HSDS-imas/hsds", "r") as dbentry:
...     ids = dbentry.get("pf_active")
... 
13:01:49 INFO     Parsing data dictionary version 4.1.1 @dd_zip.py:89
13:01:50 INFO     Parsing data dictionary version 4.0.0 @dd_zip.py:89
>>> ids
<IDSToplevel (IDS:pf_active)>
         
>>> imas.util.print_tree(ids)
pf_active
├── ids_properties
│   ├── comment: 'testing pf_active'
│   ├── homogeneous_time: 1
│   └── ids_properties/version_put
│       ├── data_dictionary: '4.0.0'
│       ├── access_layer: '5.4.3'
│       └── access_layer_language: 'imas 2.0.0.post1'
└── time: array([0.01])
>>> with imas.DBEntry("imas:hdf5?path=./HSDS-imas/hsds", "r") as dbentry:
...     ids = dbentry.get("equilibrium")
... 
>>> ids
<IDSToplevel (IDS:equilibrium)>
>>> imas.util.print_tree(ids)
equilibrium
├── ids_properties
│   ├── comment: 'testing'
│   ├── homogeneous_time: 1
│   └── ids_properties/version_put
│       ├── data_dictionary: '4.0.0'
│       ├── access_layer: '5.4.3'
│       └── access_layer_language: 'imas 2.0.0.post1'
└── time: array([0.01])
>>> 
[3]+  Stopped                 python
[sawantp1@98dci4-srv-1003 IMAS-Core]$ 
```