### PR TITLE
fix/allow-pip-to-fetch-runtime-dependencies-during-isolated-install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,13 @@ option(AL_BACKEND_MDSPLUS "Build the MDSplus backend" OFF)
 option(AL_BACKEND_HDF5 "Build the HDF5 backend" ON)
 option(AL_BACKEND_UDA "Build the UDA backend" OFF)
 option(AL_BACKEND_UDAFAT "Build the UDA backend (use FAT UDA)" OFF)
-include(CMakeDependentOption)
-cmake_dependent_option(AL_BUILD_MDSPLUS_MODELS "Build MDSplus models" ON
-AL_BACKEND_MDSPLUS OFF)
+# AL_BUILD_MDSPLUS_MODELS defaults to ON when AL_BACKEND_MDSPLUS is ON, otherwise OFF.
+# This can be overridde by user by setting AL_BUILD_MDSPLUS_MODELS explicitly to ON or OFF.
+if(AL_BACKEND_MDSPLUS)
+  option(AL_BUILD_MDSPLUS_MODELS "Build MDSplus models" ON)
+else()
+  option(AL_BUILD_MDSPLUS_MODELS "Build MDSplus models" OFF)
+endif()
 
 # Configuration options for python bindings
 # ##############################################################################

--- a/README.md
+++ b/README.md
@@ -17,45 +17,35 @@ This repository contains the **Lowlevel components of the Access Layer**:
 - **MDS+ model logic** for creating the models required by the MDS+ backend
 
 
-## Quick Installation
-
-Install IMAS-Core with a single command:
-
-```bash
-pip install imas-core
-python -c "import imas_core"
-```
-
-That's it! No need to compile or configure anything.
-
-## Features
-
-- ✅ **Easy to Install** - Single `pip install` command
-- ✅ **Multiple Formats** - HDF5, MDSplus, UDA, in-memory, and more
-- ✅ **Cross-Platform** - Works on Linux, macOS, and Windows
-- ✅ **IMAS Standard** - Access standardized fusion data structures
-- ✅ **Read & Write** - Both data access and creation supported
-
 ## Installation Options
 
-### For Python Users (Recommended)
+### For Python Users
 
 ```bash
-# Simple install from PyPI for Python applications
+# Install from PyPI
 pip install imas-core
 
 # Verify installation
 python -c "import imas; print(imas.__version__)"
 ```
 
-
 ### For Developers
 
-See [Building from Source](docs/source/user_guide/installation.rst) for detailed build instructions.
+To build IMAS-Core from source:
+
+```bash
+git clone https://github.com/iterorganization/IMAS-Core.git
+cd IMAS-Core
+cmake -Bbuild -GNinja -DAL_PYTHON_BINDINGS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/test-install"
+cmake --build build --target install
+```
+
+See [Developer Guide](docs/source/developers/index.rst) for build instructions.
+
 
 ## Using IMAS-Core with High-Level Languages
 
-When IMAS-Core is built and installed via CMake, it creates a complete runtime environment with:
+When IMAS-Core is built and installed via CMake, it installs:
 
 - **C/C++ Libraries** (`libal.so`) with full headers
 - **Python Bindings** (`imas_core` Python package)
@@ -74,90 +64,45 @@ export HDF5_USE_FILE_LOCKING=FALSE
 export PYTHONPATH="/path/to/install/lib/pythonX.X/site-packages:$PYTHONPATH"
 ```
 
-Then use IMAS-Core from your preferred language:
+Then use IMAS-Core from the required language:
 - **Python**: `import imas` (see examples above)
 - **C/C++**: Link against `libal.so` with provided headers
 - **Fortran**: Use pkg-config to get compiler flags
 - **Java**: Use `imas.jar` in your classpath
 - **MATLAB**: Add MEX directory to MATLAB path
 
+See [Building from Source](docs/source/user_guide/installation.rst) for detailed build instructions.
 
 ## Documentation
 
-- **[User Guide](docs/source/user_guide/index.rst)** - Complete user documentation
+- **[User Guide](docs/source/user_guide/index.rst)** - User documentation
 - **[Installation Guide](docs/source/user_guide/installation.rst)** - Installation instructions
 - **[Backends Guide](docs/source/user_guide/backends_guide.rst)** - Available data backends
 - **[URIs Guide](docs/source/user_guide/uris_guide.rst)** - Data entry URI documentation
 - **[Configuration](docs/source/user_guide/configuration.rst)** - Configuration options
 - **[FAQ](docs/source/faq.rst)** - Frequently asked questions
-- **[Troubleshooting](docs/source/troubleshooting.rst)** - Common issues & solutions
+- **[Troubleshooting](docs/source/troubleshooting.rst)** - Troubleshooting
 
-## System Requirements
-
-- **Python**: 3.8 or newer 
-- **OS**: Linux, macOS, or Windows
-- **pip**: 19.0 or newer
 
 ## Available Backends
 
-IMAS-Core supports multiple data storage formats:
+IMAS-Core supports these storage backends:
 
 | Backend | Use Case | Remote | File-based |
 |---------|----------|--------|-----------|
 | **HDF5** | Default, local storage | No | Yes |
 | **MDSplus** | ITER experiments | Yes | No |
 | **UDA** | Distributed access | Yes | No |
-| **Memory** | Testing, IPC | No | No |
+| **Memory** | Testing | No | No |
 | **FlexBuffers** | Message passing | No | Yes |
 | **ASCII** | Debugging | No | Yes |
 
-## Troubleshooting
 
-**Can't find file?**
-```python
-# Check file path
-import os
-print(os.path.exists('/path/to/file.h5'))
-```
-
-**Need help?**
+**Help**
 - See [Troubleshooting Guide](docs/source/troubleshooting.rst)
 - Check [FAQ](docs/source/faq.rst)
 - Open an [Issue on GitHub](https://github.com/iterorganization/IMAS-Core/issues)
 
-## What's Included?
-
-IMAS-Core provides:
-
-- **Python API** - Full Python bindings with NumPy support
-- **Multiple Backends** - HDF5, MDSplus, UDA, and more
-- **Data Creation** - Create and populate IMAS IDS structures
-- **Data Access** - Read from multiple sources transparently
-- **Standard Format** - IMAS standardized data structures
-
-## For Developers
-
-To build IMAS-Core from source:
-
-```bash
-git clone https://github.com/iterorganization/IMAS-Core.git
-cd IMAS-Core
-cmake -Bbuild -GNinja -DAL_PYTHON_BINDINGS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/test-install"
-cmake --build build --target install
-```
-
-### `AL_PYTHON_BINDINGS` options
-
-This CMake option controls how the `imas_core` Python package is built.
-
-| Value | When to use |
-|---|---|
-| `ON` | (default) pip builds the wheel in an isolated environment and downloads build dependencies automatically. |
-| `no-build-isolation` | `numpy` etc build dependencies are already available in the environment. |
-| `editable` or `e` | Development. Installs `imas_core` in editable mode (`pip install --editable`) | 
-
-
-See [Developer Guide](docs/source/developers/index.rst) for detailed instructions.
 
 ## Links
 
@@ -176,4 +121,3 @@ IMAS-Core is released under the [LGPL-3.0 License](LICENSE.txt)
 - **Email**: imas-support@iter.org
 - **Documentation**: https://imas-core.readthedocs.io/
 - **Issues**: https://github.com/iterorganization/IMAS-Core/issues
-

--- a/README.md
+++ b/README.md
@@ -146,6 +146,17 @@ cmake -Bbuild -GNinja -DAL_PYTHON_BINDINGS=ON -DCMAKE_INSTALL_PREFIX="$(pwd)/tes
 cmake --build build --target install
 ```
 
+### `AL_PYTHON_BINDINGS` options
+
+This CMake option controls how the `imas_core` Python package is built.
+
+| Value | When to use |
+|---|---|
+| `ON` | (default) pip builds the wheel in an isolated environment and downloads build dependencies automatically. |
+| `no-build-isolation` | `numpy` etc build dependencies are already available in the environment. |
+| `editable` or `e` | Development. Installs `imas_core` in editable mode (`pip install --editable`) | 
+
+
 See [Developer Guide](docs/source/developers/index.rst) for detailed instructions.
 
 ## Links

--- a/common/doc_common/building_installing.rst
+++ b/common/doc_common/building_installing.rst
@@ -227,9 +227,10 @@ Configuration options
     -   ``AL_BACKEND_MDSPLUS``, allowed values ``ON`` or ``OFF`` *(default)*.
         Enable/disable the MDSplus backend.
 
-        -   ``AL_BUILD_MDSPLUS_MODELS``, allowed values ``ON`` *(default)* or ``OFF``,
-            only available when the MDSplus backend is enabled. Enable building MDSplus
-            models for the selected Data Dictionary version.
+        -   ``AL_BUILD_MDSPLUS_MODELS``, allowed values ``ON`` or ``OFF``.
+            Enable building MDSplus models for the selected Data Dictionary version.
+            Defaults to ``ON`` when ``AL_BACKEND_MDSPLUS`` is enabled, ``OFF`` otherwise.
+            Can be overridden by user to explicitly enable or disable building MDSplus models.
 
     -   ``AL_BACKEND_UDA``, allowed values ``ON`` or ``OFF`` *(default)*. Enable/disable
         the UDA backend.

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -259,7 +259,7 @@ Configuration options
         `--no-deps` prevents pip from installing or upgrading dependencies.
         This keeps the CMake install step local and reproducible: only the wheel built
         by this build is installed, and dependencies are expected to be provided by the
-        user's environment, EasyBuild or system installation.
+        user's environment or system installation.
 
         When not using CMake to build the Python bindings, you can install the `imas_core` with `pip install .`
         command without specifying above options. `imas_core` will install with pip's normal build isolation.

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -240,8 +240,30 @@ Configuration options
         ONLY the documentation will be built (needs ``AL_HLI_DOCS=ON``). Regardless of
         other configuration options, nothing else will be built.
     -   ``AL_PYTHON_BINDINGS``, allowed values ``ON`` *(default when building the Python
-        API)* or ``OFF`` *(default when not building the Python API)*. When enabled, this
-        builds the Access Layer Python lowlevel bindings.
+        API)* or ``OFF`` *(default when not building the Python API)*. This CMake option 
+        controls whether and how the `imas_core` Python package is built when installing 
+        through CMake.
+
+        | Value | When to use |
+        |---|---|
+        | `OFF` | Default for CMake builds. Build and install only the native IMAS-Core library, without Python bindings. |
+        | `ON` | Build the `imas_core` wheel using pip's normal build isolation. Build dependencies will be installed by pip. |
+        | `no-build-isolation` | Build the `imas_core` wheel using the current Python environment. Use this when build dependencies like `numpy` are already installed. |
+        | `editable` or `e` | Development mode. Install `imas_core` with `pip install --editable`, so Python changes can be used without reinstalling. |
+
+        When CMake installs the Python bindings, it first builds a local wheel and then
+        installs that wheel with `pip install --no-index --no-deps --find-links
+        <build>/dist`. 
+        `--no-index` prevents pip from searching PyPI or another package
+        index, and 
+        `--no-deps` prevents pip from installing or upgrading dependencies.
+        This keeps the CMake install step local and reproducible: only the wheel built
+        by this build is installed, and dependencies are expected to be provided by the
+        user's environment, EasyBuild or system installation.
+
+        When not using CMake to build the Python bindings, you can install the `imas_core` with `pip install .`
+        command without specifying above options. `imas_core` will install with pip's normal build isolation.
+
 
 -   **Dependency configuration options**
 

--- a/docs/source/user_guide/installation.rst
+++ b/docs/source/user_guide/installation.rst
@@ -219,9 +219,10 @@ Configuration options
     -   ``AL_BACKEND_MDSPLUS``, allowed values ``ON`` or ``OFF`` *(default)*.
         Enable/disable the MDSplus backend.
 
-        -   ``AL_BUILD_MDSPLUS_MODELS``, allowed values ``ON`` *(default)* or ``OFF``,
-            only available when the MDSplus backend is enabled. Enable building MDSplus
-            models for the selected Data Dictionary version.
+        -   ``AL_BUILD_MDSPLUS_MODELS``, allowed values ``ON`` or ``OFF``.
+            Enable building MDSplus models for the selected Data Dictionary version.
+            Defaults to ``ON`` when ``AL_BACKEND_MDSPLUS`` is enabled, ``OFF`` otherwise.
+            Can be overridden by user to explicitly enable or disable building MDSplus models.
 
     -   ``AL_BACKEND_UDA``, allowed values ``ON`` or ``OFF`` *(default)*. Enable/disable
         the UDA backend.

--- a/skbuild.cmake
+++ b/skbuild.cmake
@@ -51,7 +51,6 @@ set_target_properties(
   al-python-bindings PROPERTIES DIST_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/dist/)
 install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} 
 -m pip install imas_core
---no-index
 --prefix=${CMAKE_INSTALL_PREFIX}
 --find-links ${CMAKE_CURRENT_BINARY_DIR}/dist/
 )"

--- a/skbuild.cmake
+++ b/skbuild.cmake
@@ -51,6 +51,8 @@ set_target_properties(
   al-python-bindings PROPERTIES DIST_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/dist/)
 install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} 
 -m pip install imas_core
+--no-index
+--no-deps
 --prefix=${CMAKE_INSTALL_PREFIX}
 --find-links ${CMAKE_CURRENT_BINARY_DIR}/dist/
 )"


### PR DESCRIPTION
Removed `--no-index` from the pip install command so that runtime dependencies like `numpy `can be fetched from `PyPI`. 
when we have `AL_PYTHON_BINDINGS=ON` in the cmake configuration, `--no-index `was restricting pip to use dependencies from local folder, it was causing install error like below.

```bash
Processing ./dist/imas_core-5.6.1.dev4-cp311-cp311-linux_x86_64.whl
INFO: pip is looking at multiple versions of imas-core to determine which version is compatible with other requirements. This could take a while.
ERROR: Could not find a version that satisfies the requirement numpy (from imas-core) (from versions: none)
ERROR: No matching distribution found for numpy
```

*Note : Tested it locally but need to confirm this behavior on all the platforms