### PR TITLE
Added optional argument "mode"

### DIFF
--- a/src/uda/uda_backend.cpp
+++ b/src/uda/uda_backend.cpp
@@ -1332,6 +1332,7 @@ void UDABackend::get_occurrences(Context* ctx, const char* ids_name, int** occur
     ss << plugin_
        << "::getOccurrences("
        << "uri='" << uri << "'"
+       << ", mode='" << imas::uda::convert_imas_to_uda<imas::uda::OpenMode>(OPEN_PULSE) << "'"
        << ", ids='" << ids_name << "'"
        << ")";
 
@@ -1390,6 +1391,7 @@ void UDABackend::list_filled_paths(Context* ctx, const char* dataobjectname, cha
     ss << plugin_
        << "::listFilledPaths("
        << "uri='" << uri << "'"
+       << ", mode='" << imas::uda::convert_imas_to_uda<imas::uda::OpenMode>(OPEN_PULSE) << "'"
        << ", ids='" << dataobjectname << "'"
        << ")";
 


### PR DESCRIPTION
- Added optional argument "mode" in getOccurrences and listFilledPaths APIs
- Fix URI reopen with small UDA_TIMEOUT

When using a small UDA_TIMEOUT (e.g. 2s), the previous request may time out,
requiring the URI to be reopened. Reopening the URI now correctly uses
OPEN_PULSE mode.

Fixes https://github.com/iterorganization/UDA-Plugins/issues/5


