### PR TITLE
Guarding against HDF5-reads with wrongly shaped datasets (inconsistencies in the file)

### DIFF
--- a/src/hdf5/hdf5_reader.cpp
+++ b/src/hdf5/hdf5_reader.cpp
@@ -1288,6 +1288,18 @@ int HDF5Reader::readPersistentShapes_Get(Context *ctx, hid_t gid, const std::str
         new_data_set->open(tensorized_path.c_str(), gid, &dataset_id, 1, nullptr, alconst::integer_data, true, true, dec->getURI());
         if (!(new_data_set->dataset_id >= 0))
             throw ALBackendException("HDF5Backend: unexpected dataset_id value in HDF5Reader::readPersistentShapes_Get()", LOG);
+
+        {
+            int shape_rank = new_data_set->getRank();
+            int expected_rank = static_cast<int>(current_arrctx_indices.size()) + 1;
+            if (shape_rank != expected_rank) {
+                throw ALBackendException(
+                    "HDF5Backend: SHAPE dataset '" + tensorized_path
+                    + "' has rank " + std::to_string(shape_rank)
+                    + " but rank " + std::to_string(expected_rank) + " was expected. ",
+                    LOG);
+            }
+        }
         *dataset_id_shapes = dataset_id;
         int dim = -1;
         auto hsSelectionReader = std::unique_ptr<HDF5HsSelectionReader>(new HDF5HsSelectionReader(new_data_set->getRank(), new_data_set->dataset_id,
@@ -1325,6 +1337,22 @@ int HDF5Reader::readPersistentShapes_GetSlice(Context *ctx,
         DataEntryContext *dec = getDataEntryContext(ctx);
         std::unique_ptr<HDF5DataSetHandler> new_data_set(new HDF5DataSetHandler(false, dec->getURI()));
         new_data_set->open(tensorized_path.c_str(), gid, &dataset_id, 1, nullptr, alconst::integer_data, true, true, dec->getURI());
+
+        // Validate _SHAPE dataset rank before any index arithmetic.
+        {
+            int shape_rank = new_data_set->getRank();
+            int expected_rank = static_cast<int>(aos_indices.size()) + 1;
+            if (shape_rank != expected_rank) {
+                throw ALBackendException(
+                    "HDF5Backend: SHAPE dataset '" + tensorized_path
+                    + "' has rank " + std::to_string(shape_rank)
+                    + " but rank " + std::to_string(expected_rank) + " was expected. "
+                    "The file was likely written by a direct HDF5/h5py writer or an "
+                    "incompatible imas-python version that uses a different _SHAPE rank "
+                    "convention. Re-generate the file using a supported imas-python release.",
+                    LOG);
+            }
+        }
         int dim = -1;
         auto hsSelectionReader = std::unique_ptr<HDF5HsSelectionReader>(new HDF5HsSelectionReader(new_data_set->getRank(), dataset_id,
                                                                                                   new_data_set->getDataSpace(), new_data_set->getLargestDims(), alconst::integer_data, aos_indices.size(), &dim));

--- a/src/hdf5/hdf5_reader.cpp
+++ b/src/hdf5/hdf5_reader.cpp
@@ -1338,7 +1338,6 @@ int HDF5Reader::readPersistentShapes_GetSlice(Context *ctx,
         std::unique_ptr<HDF5DataSetHandler> new_data_set(new HDF5DataSetHandler(false, dec->getURI()));
         new_data_set->open(tensorized_path.c_str(), gid, &dataset_id, 1, nullptr, alconst::integer_data, true, true, dec->getURI());
 
-        // Validate _SHAPE dataset rank before any index arithmetic.
         {
             int shape_rank = new_data_set->getRank();
             int expected_rank = static_cast<int>(aos_indices.size()) + 1;
@@ -1346,10 +1345,7 @@ int HDF5Reader::readPersistentShapes_GetSlice(Context *ctx,
                 throw ALBackendException(
                     "HDF5Backend: SHAPE dataset '" + tensorized_path
                     + "' has rank " + std::to_string(shape_rank)
-                    + " but rank " + std::to_string(expected_rank) + " was expected. "
-                    "The file was likely written by a direct HDF5/h5py writer or an "
-                    "incompatible imas-python version that uses a different _SHAPE rank "
-                    "convention. Re-generate the file using a supported imas-python release.",
+                    + " but rank " + std::to_string(expected_rank) + " was expected. ",
                     LOG);
             }
         }

--- a/src/hdf5/hdf5_reader.cpp
+++ b/src/hdf5/hdf5_reader.cpp
@@ -1297,6 +1297,7 @@ int HDF5Reader::readPersistentShapes_Get(Context *ctx, hid_t gid, const std::str
                     "HDF5Backend: SHAPE dataset '" + tensorized_path
                     + "' has rank " + std::to_string(shape_rank)
                     + " but rank " + std::to_string(expected_rank) + " was expected. ",
+                    + "This may indicate issues in the data production process. "
                     LOG);
             }
         }
@@ -1346,6 +1347,7 @@ int HDF5Reader::readPersistentShapes_GetSlice(Context *ctx,
                     "HDF5Backend: SHAPE dataset '" + tensorized_path
                     + "' has rank " + std::to_string(shape_rank)
                     + " but rank " + std::to_string(expected_rank) + " was expected. ",
+                    + "This may indicate issues in the data production process. "
                     LOG);
             }
         }


### PR DESCRIPTION
fixes a crash when reading some HDF5 shape datasets through the
buffered read path also fixes the same indexing problem in the buffered write path.

    ids.grid_ggd[0].space[0].objects_per_dimension[3].object[0].geometry[0]
```bash
    h5ls -r "/home/ITER/pankina/public/d3d/4/163518/75/mhd_1.h5" | grep 'grid_ggd\[\]&space\[\]&objects_per_dimension\[\]&object\[\]&geometry'
    /mhd_1/grid_ggd[]&space[]&objects_per_dimension[]&object[]&geometry Dataset {2/Inf, 1, 4, 3702416/Inf, 3}
    /mhd_1/grid_ggd[]&space[]&objects_per_dimension[]&object[]&geometry_SHAPE Dataset {2/Inf, 1, 4, 3702416/Inf}
```

``geometry`` stores the actual values and has 5 dimensions

    [grid_ggd, space, objects_per_dimension, object, geometry_value]

``geometry_SHAPE`` stores the length of ``geometry`` for each object. It has
only 4 dimensions::

    [grid_ggd, space, objects_per_dimension, object]

`indices.push_back(0);` always added one extra index when reading or writing 1D data.
That is correct for ``geometry``, but wrong for ``geometry_SHAPE``.

checks the dataset rank before adding the extra index.

* If the dataset needs one more index, add ``0``.
* If the dataset already has enough indices, do not add anything.
* If the number of indices is still wrong, throw an exception 

```bash
$ python test.py
16:14:37 INFO     Parsing data dictionary version 4.1.1 @dd_zip.py:89
╭─────────────────── IDS structure: grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0] (DD version 4.1.1) ────────────────────╮
│ Set of objects for a given dimension                                                                                             │
│ ╭───────────────────────────────────────────────────────── Attributes ─────────────────────────────────────────────────────────╮ │
│ │ metadata = <IDSMetadata for 'object'>                                                                                        │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
│ ╭──────────────────────────────────────────────────────── Child nodes ─────────────────────────────────────────────────────────╮ │
│ │    boundary = <IDSStructArray (IDS:mhd, grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0]/boundary with 5 items)>      │ │
│ │    geometry = <IDSNumericArray (IDS:mhd, grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0]/geometry, empty FLT_1D)>    │ │
│ │ geometry_2d = <IDSNumericArray (IDS:mhd, grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0]/geometry_2d, empty FLT_2D)> │ │
│ │     measure = <IDSFloat0D (IDS:mhd, grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0]/measure, empty FLT_0D)>          │ │
│ │       nodes = <IDSNumericArray (IDS:mhd, grid_ggd[0]/space[0]/objects_per_dimension[3]/object[0]/nodes, INT_1D)>             │ │
│ │               numpy.ndarray([     1,      2,    643, 231402, 231403, 232044], dtype=int32)                                   │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
