### PR TITLE
ci: add dependabot.yml to update github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    # Look for `/.github/workflows` and `/action.yml` or `.yaml`
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
This should bump the versions of GH actions in `.github/workflows/*.yml`, every [Monday](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval)...  (and also the first time after merging this PR)



----

PS.
Before you ask, why not a fork and pull-request?
I tried using the GH interface in this org, to select a branch `Louwrensth:ci/update-actions` it didn't complain, removed the `:` and created this one instead :(