### PR TITLE
Fix OOB read / segfault when reading SHAPE-scalar HDF5 datasets

### DIFF
--- a/src/hdf5/hdf5_dataset_handler.cpp
+++ b/src/hdf5/hdf5_dataset_handler.cpp
@@ -1085,11 +1085,21 @@ void HDF5DataSetHandler::readIntNDFromBuffer(HDF5HsSelectionReader & hsSelection
     *data = (void*) malloc(shape*sizeof(int));
     if (rank != dim) {
         HDF5Utils hdf5_utils;
-        std::vector < int > indices = current_arrctx_indices;
-        indices.push_back(0);
-        int index = hdf5_utils.indices_to_flat_index(indices, hsSelectionReader.getDataSpaceDims());
+        int index;
+        if (dim != 0) {
+            std::vector < int > indices = current_arrctx_indices;
+            indices.push_back(0);
+            index = hdf5_utils.indices_to_flat_index(indices, hsSelectionReader.getDataSpaceDims());
+        }
+        else {
+            // SHAPE-like datasets store one scalar per AOS cell: the index list
+            // already matches the dataset rank, so appending the trailing
+            // value-dimension index over-extends it and reads out of bounds.
+            // Mirrors the guard in fillFullBuffers().
+            index = hdf5_utils.indices_to_flat_index(current_arrctx_indices, hsSelectionReader.getDataSpaceDims());
+        }
         memcpy(*data, v+index, shape*sizeof(int));
-        
+
     }
     else {
         memcpy(*data, v, shape*sizeof(int));
@@ -1108,11 +1118,21 @@ void HDF5DataSetHandler::readDoubleNDFromBuffer(HDF5HsSelectionReader & hsSelect
     *data = (void*) malloc(shape*sizeof(double));
     if (rank != dim) {
         HDF5Utils hdf5_utils;
-        std::vector < int > indices = current_arrctx_indices;
-        indices.push_back(0);
-        int index = hdf5_utils.indices_to_flat_index(indices, hsSelectionReader.getDataSpaceDims());
+        int index;
+        if (dim != 0) {
+            std::vector < int > indices = current_arrctx_indices;
+            indices.push_back(0);
+            index = hdf5_utils.indices_to_flat_index(indices, hsSelectionReader.getDataSpaceDims());
+        }
+        else {
+            // SHAPE-like datasets store one scalar per AOS cell: the index list
+            // already matches the dataset rank, so appending the trailing
+            // value-dimension index over-extends it and reads out of bounds.
+            // Mirrors the guard in fillFullBuffers().
+            index = hdf5_utils.indices_to_flat_index(current_arrctx_indices, hsSelectionReader.getDataSpaceDims());
+        }
         memcpy(*data, v+index, shape*sizeof(double));
-    } 
+    }
     else {
         memcpy(*data, v, shape*sizeof(double));
     }


### PR DESCRIPTION
# Fix OOB read / segfault when reading SHAPE-scalar HDF5 datasets

Closes #51. Alternative to #52.

## Problem

Reading GGD geometry data segfaults inside the HDF5 reader, e.g.:

```python
ids.grid_ggd[0].space[0].objects_per_dimension[3].object[0].geometry[0]
```

crashes with `SIGSEGV` in `__intel_avx_rep_memcpy` (see the backtrace in #51).

## Root cause

`HDF5HsSelectionReader` computes `dim = dataset_rank - AOSRank`. For a `*_SHAPE`
dataset whose rank equals the AOS depth, `dim == 0` while `rank > 0`.

`readIntNDFromBuffer` and `readDoubleNDFromBuffer` then take the `rank != dim`
branch and **unconditionally** append a trailing value-dimension index before
computing the flat offset:

```cpp
std::vector<int> indices = current_arrctx_indices;   // size == rank
indices.push_back(0);                                // -> size rank + 1
int index = hdf5_utils.indices_to_flat_index(indices, hsSelectionReader.getDataSpaceDims());
memcpy(*data, v + index, shape * sizeof(int));
```

`indices_to_flat_index` iterates `indices.size()` times reading `dataSpaceDims[i]`,
so the extra element reads one past the dims array and folds it into the offset.
The resulting `index` is out of range and the `memcpy` reads unmapped memory.

Notably, the buffered **write** path (`fillFullBuffers()`) already handles this
correctly — it guards the same `push_back` with `if (request_dim != 0)` and, when
`dim == 0`, indexes directly from the AOS indices. The read-from-buffer functions
were simply missing that guard.

## Fix

Mirror the existing write-path guard into both read functions: only append the
trailing index when `dim != 0`; otherwise address the scalar directly from
`current_arrctx_indices`. Minimal, symmetric with `fillFullBuffers()`, and it
lets the read return the correct value instead of crashing.

## Why this as an alternative to #52

#52 addresses the same issue from the caller side by adding rank checks in
`readPersistentShapes_Get` / `_GetSlice` that throw an `ALBackendException` when
the SHAPE-dataset rank does not match `arrctx_indices.size() + 1`. That removes
the undefined behaviour, but for the reproduction case the rank is exactly
`arrctx_indices.size()`, so the guard converts the crash into a thrown
exception — the GGD geometry still cannot be read. (The PR description for #52
also describes a conditional-`push_back` fix and a write-path change that are not
present in its diff.)

This PR instead fixes the indexing at its source, so the affected reads succeed.
The two approaches are not mutually exclusive: #52's guard could be kept as a
defence-in-depth safety net (with its condition relaxed so it does not reject the
legitimate `rank == AOSRank` SHAPE case), but it is not required once the
indexing is correct.

## Verification

Reproduced the crash on the released `IMAS-Core/5.6.0` modules (both `intel-2023b`
and `foss-2023b`) with the script from #51 → `SIGSEGV` (exit 139).

Built `libal` from this branch and re-ran with the patched library preloaded over
the released Python extension (so the patched C library is the only thing that
changed):

| Case | Unpatched 5.6.0 | Patched |
|---|---|---|
| GGD geometry read (#51 repro) | SIGSEGV (exit 139) | empty array, exit 0 |
| Non-empty FLT_1D (point coordinates, `objects_per_dimension[0]`) | — | reads correctly |
| Non-empty INT_1D (`nodes`, sampled across the full object range) | — | reads correctly |

Both value-dimension branches (`dim != 0`, int and double) and the new `dim == 0`
branch are exercised.

## Follow-up suggestions (not in this PR)

- Harden `indices_to_flat_index` to take a rank/length and assert/throw if the
  index count exceeds it, so any future caller bug fails loudly instead of
  reading out of bounds.
- Add a regression test using a `*_SHAPE` dataset whose rank equals the AOS depth.
