### PR TITLE
fix documentation of HDF5 backend options

### DIFF
--- a/docs/source/user_guide/backends_guide.rst
+++ b/docs/source/user_guide/backends_guide.rst
@@ -178,9 +178,10 @@ The :ref:`HDF5 backend` also recognizes these backend-specific query keys.
     arrives, which reduces peak memory usage at the cost of slower writes).
 
 ``hdf5_read_buffering``
-    During a ``get`` operation, field data read from HDF5 is buffered in memory
-    before being returned to the caller.
-
+    During a get operation, supported 0D and 1D field data read from HDF5 is
+    buffered in memory before being returned to the caller. Slice and time range
+    reads, as well as fields with higher dimensionality, are read directly.
+    
     This feature is enabled by default. Set ``hdf5_read_buffering=no`` to
     disable read buffering.
 

--- a/docs/source/user_guide/backends_guide.rst
+++ b/docs/source/user_guide/backends_guide.rst
@@ -166,27 +166,38 @@ Query keys specific for the HDF5 backend
 The :ref:`HDF5 backend` also recognizes these backend-specific query keys.
 
 ``hdf5_compression``
-    Data compression is enabled by default. Set ``hdf5_compression=no`` or
-    ``hdf5_compression=n`` to disable data compression.
+    Data compression is enabled by default. Set ``hdf5_compression=no``
+    to disable data compression.
 
 ``hdf5_write_buffering``
-    During a `put` operation, 0D and 1D buffers are first
-    stored in memory. Buffers are flushed at the end of the put.
-    
-    This feature is enabled by default. Set ``hdf5_write_buffering=no`` or
-    ``hdf5_write_buffering=n`` to disable write buffering.
+    During a ``put`` operation, 0D and 1D field buffers are first stored in
+    memory and flushed to HDF5 in a single write at the end of the put.
 
-``write_cache_option``
-    Set the size of the HDF5 chunk cache used during chunked datasets write
-    operations. Default to 100x1024x1024 bytes (100 MiB).
+    This feature is enabled by default. Set ``hdf5_write_buffering=no`` to
+    disable write buffering (data is written to HDF5 field-by-field as it
+    arrives, which reduces peak memory usage at the cost of slower writes).
 
-``read_cache_option``
-    Set the size of the HDF5 chunk cache used during chunked datasets read
-    operations. Default to 5x1024x1024 bytes (5 MiB).
+``hdf5_read_buffering``
+    During a ``get`` operation, field data read from HDF5 is buffered in memory
+    before being returned to the caller.
 
-``open_read_only``
-    Open master file and IDSs files in read only if ``open_read_only=yes`` or
-    ``open_read_only=y``, overwriting the files access modes default behavior (see IMAS-5274 for an example use-case).
+    This feature is enabled by default. Set ``hdf5_read_buffering=no`` to
+    disable read buffering.
+
+``hdf5_write_cache``
+    Set the size (in MiB) of the HDF5 per-dataset chunk cache used during write
+    operations. The cache is allocated per open dataset, so the aggregate memory
+    grows with the number of datasets written simultaneously.
+
+    Default: ``100`` (MiB). Can also be set via the environment variable
+    ``HDF5_BACKEND_WRITE_CACHE=<MiB>``.
+
+``hdf5_read_cache``
+    Set the size (in MiB) of the HDF5 per-dataset chunk cache used during read
+    operations.
+
+    Default: ``5`` (MiB). Can also be set via the environment variable
+    ``HDF5_BACKEND_READ_CACHE=<MiB>``.
 
 ``hdf5_debug``
     HDF5 debug output is disabled by default. Set ``hdf5_debug=yes`` or

--- a/docs/source/user_guide/configuration.rst
+++ b/docs/source/user_guide/configuration.rst
@@ -10,40 +10,10 @@ variables. This page provides an overview of the available options.
 Environment variables controlling IMAS-Core behaviour
 -----------------------------------------------------
 
-``IMAS_AL_DEFAULT_BACKEND`` [#backend_env]_
-    Specify which backend to use by default with open/create methods that do not
-    pass this information as an argument. Values for this environment
-    variable correspond to the targeted backend ID, see below table. If not
-    specified, the MDS+ backend is the default.
-
-    .. csv-table:: Backend IDs
-        :header-rows: 1
-
-        Backend, Backend ID
-        :ref:`ASCII <ascii backend>`, 11
-        :ref:`MDSplus <mdsplus backend>`, 12
-        :ref:`HDF5 <hdf5 backend>`, 13
-        :ref:`Memory <memory backend>`, 14
-        :ref:`UDA <uda backend>`, 15
-    
-
-``IMAS_AL_FALLBACK_BACKEND`` [#backend_env]_
-    Specify a fallback backend to be tried if opening the given data-entry was
-    not successful with the primary/default backend. Values for this environment
-    variable correspond to the targeted backend ID, see above table. If not
-    specified, no secondary attempt will be made. This does not have any effect
-    on calls to create new dataentries.
-
-
 ``IMAS_AL_DISABLE_OBSOLESCENT_WARNING``
     Since version 4.10.0, all interfaces print warnings when putting an IDS that
     contains data in fields marked as `obsolescent` in the DD. Setting this
     variable to ``1`` disables these printouts.
-
-
-.. [#backend_env] These environment variables are not applicable when using
-    Data entry URIs (see :doc:`../user_guide/uris_guide`), which explicitly specify the backend. Also not applicable
-    in the Pythonens-user API.
 
 
 ``IMAS_LOCAL_HOSTS``
@@ -97,7 +67,7 @@ Backend specific environment variables
 
 
 ``HDF5_BACKEND_WRITE_CACHE`` [#uri_precedence]_
-    Specify the size of the write cache in MB (default is 5). It may improve
+    Specify the size of the write cache in MB (default is 100). It may improve
     writing performance at the cost of increased memory consumption. Obtained
     performance and best size of cache is heavily depending on the data.
 


### PR DESCRIPTION
Found some inconsistencies between the doc and the code in https://github.com/iterorganization/IMAS-Core/blob/develop/src/hdf5/hdf5_utils.cpp#L732

Note that open_read_only was described be never added to the code (cf. https://git.iter.org/projects/IMAS/repos/al-core/pull-requests/56/overview). Maybe these commits can be added in the new repo?